### PR TITLE
Change source url to use long SHA in SPEC file

### DIFF
--- a/paper-icon-theme.spec
+++ b/paper-icon-theme.spec
@@ -25,7 +25,7 @@ Group:		System/GUI/Other
 License:    CC-BY-SA-4.0
 Group:      System/GUI/GNOME
 Url:        http://samuelhewitt.com/paper/icons
-Source0:    https://github.com/snwh/%{name}/archive/%{name}-%{commit0}.tar.gz
+Source0:    https://github.com/snwh/%{name}/archive/%{commit0}.tar.gz
 Requires:	hicolor-icon-theme, gnome-icon-theme
 BuildArch:	noarch
 

--- a/paper-icon-theme.spec
+++ b/paper-icon-theme.spec
@@ -15,7 +15,6 @@
 
 # GitHub Stuff
 %global commit0 40-CHARACTER-HASH-VALUE
-%global shortcommit0 %(c=%{commit0}; echo ${c:0:7})
 
 name:		paper-icon-theme
 version:	1.0
@@ -26,7 +25,7 @@ Group:		System/GUI/Other
 License:    CC-BY-SA-4.0
 Group:      System/GUI/GNOME
 Url:        http://samuelhewitt.com/paper/icons
-Source0:    https://github.com/snwh/%{name}/archive/%{commit0}.tar.gz#/%{name}-%{shortcommit0}.tar.gz
+Source0:    https://github.com/snwh/%{name}/archive/%{name}-%{commit0}.tar.gz
 Requires:	hicolor-icon-theme, gnome-icon-theme
 BuildArch:	noarch
 


### PR DESCRIPTION
This will resolve build error.

So if the commit has `SHA f4eed09e05c4c925e39be205339c0852a4c8c2a0`, there should be a file named `paper-icon-theme-f4eed09e05c4c925e39be205339c0852a4c8c2a0.tar.gz` under `SOURCES` and *not* `paper-icon-theme-f4eed09.tar.gz`