### PR TITLE
install.sh: Use install -d instead of mkdir

### DIFF
--- a/install-icon-theme.sh
+++ b/install-icon-theme.sh
@@ -90,12 +90,8 @@ elif [ "$UID" -ne "$ROOT_UID" ]; then
 	fi
 	echo "Installing..."
 	# .local/share/icons
-	if [ -d $HOME/.local/share/icons ]; then
-		cp -RH ./Paper/ $HOME/.local/share/icons/
-	else
-		mkdir -p $HOME/.local/share/icons
-		cp -RH ./Paper/ $HOME/.local/share/icons/
-	fi
+	install -d $HOME/.local/share/icons
+	cp -RH ./Paper/ $HOME/.local/share/icons/
 	show_success "Installation complete!"
 	echo
 	useicons


### PR DESCRIPTION
Instead of checking for the existence of a directory, and repeating the same code in both branches (with an mkdir added in the else branch), use install -d to create the directory if it does not exist.

This simplifies the code a little, by removing a bit of repetition.
