### PR TITLE
add symlinks for Chrome tray icon

### DIFF
--- a/Paper/22x22/panel/google-chrome-tray.svg
+++ b/Paper/22x22/panel/google-chrome-tray.svg
@@ -1,0 +1,1 @@
+google-chrome-panel.svg

--- a/Paper/24x24/panel/google-chrome-tray.svg
+++ b/Paper/24x24/panel/google-chrome-tray.svg
@@ -1,0 +1,1 @@
+google-chrome-panel.svg


### PR DESCRIPTION
The icon names are used by a script that fixes Hardcoded Tray icons, so i created a symlink to those icons

Edit : 
How it looks like after the symlink
![capture du 2016-05-15 16-15-13](https://cloud.githubusercontent.com/assets/7660997/15274661/39a0ed5a-1ab8-11e6-9d9b-720669e0ed39.png)

Thanks!