### PR TITLE
add symlink for icedove

### DIFF
--- a/Paper/16x16/apps/icedove.png
+++ b/Paper/16x16/apps/icedove.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/Paper/16x16@2x/apps/icedove.png
+++ b/Paper/16x16@2x/apps/icedove.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/Paper/24x24/apps/icedove.png
+++ b/Paper/24x24/apps/icedove.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/Paper/24x24@2x/apps/icedove.png
+++ b/Paper/24x24@2x/apps/icedove.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/Paper/32x32/apps/icedove.png
+++ b/Paper/32x32/apps/icedove.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/Paper/32x32@2x/apps/icedove.png
+++ b/Paper/32x32@2x/apps/icedove.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/Paper/48x48/apps/icedove.png
+++ b/Paper/48x48/apps/icedove.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/Paper/48x48@2x/apps/icedove.png
+++ b/Paper/48x48@2x/apps/icedove.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/Paper/512x512/apps/icedove.png
+++ b/Paper/512x512/apps/icedove.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/Paper/512x512@2x/apps/icedove.png
+++ b/Paper/512x512@2x/apps/icedove.png
@@ -1,0 +1,1 @@
+internet-mail.png


### PR DESCRIPTION
Small followup to #285:
Thunderbird is still called *icedove* in Debian, so I also added a symlink for it.
