### PR TITLE
Added symlinks for Ephy 3.23.x

### DIFF
--- a/Paper/16x16/apps/org.gnome.Epiphany.png
+++ b/Paper/16x16/apps/org.gnome.Epiphany.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/Paper/16x16@2x/apps/org.gnome.Epiphany.png
+++ b/Paper/16x16@2x/apps/org.gnome.Epiphany.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/Paper/24x24/apps/org.gnome.Epiphany.png
+++ b/Paper/24x24/apps/org.gnome.Epiphany.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/Paper/24x24@2x/apps/org.gnome.Epiphany.png
+++ b/Paper/24x24@2x/apps/org.gnome.Epiphany.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/Paper/32x32/apps/org.gnome.Epiphany.png
+++ b/Paper/32x32/apps/org.gnome.Epiphany.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/Paper/32x32@2x/apps/org.gnome.Epiphany.png
+++ b/Paper/32x32@2x/apps/org.gnome.Epiphany.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/Paper/48x48/apps/org.gnome.Epiphany.png
+++ b/Paper/48x48/apps/org.gnome.Epiphany.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/Paper/48x48@2x/apps/org.gnome.Epiphany.png
+++ b/Paper/48x48@2x/apps/org.gnome.Epiphany.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/Paper/512x512/apps/org.gnome.Epiphany.png
+++ b/Paper/512x512/apps/org.gnome.Epiphany.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/Paper/512x512@2x/apps/org.gnome.Epiphany.png
+++ b/Paper/512x512@2x/apps/org.gnome.Epiphany.png
@@ -1,0 +1,1 @@
+internet-web-browser.png

--- a/Paper/scalable/apps/org.gnome.Epiphany-symbolic.svg
+++ b/Paper/scalable/apps/org.gnome.Epiphany-symbolic.svg
@@ -1,0 +1,1 @@
+web-browser-symbolic.svg


### PR DESCRIPTION
Hi.

In GNOME 3.23 cycle, I have an issue 'missing web-browser icons' for Epiphany.
Upstream renamed its icon name from 'web-browser' to 'org.gnome.Epiphany':
https://git.gnome.org/browse/epiphany/commit/?id=35afef947e612887a40a8d539ffd1cd2a16ad110

I'm happy if you could merge these changes into master.
Thanks for your great work!! :)

Best Regards,
Tista