### PR TITLE
Add symlinks for Ghetto Skype

### DIFF
--- a/Paper/16x16/apps/ghetto-skype.png
+++ b/Paper/16x16/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Paper/16x16@2x/apps/ghetto-skype.png
+++ b/Paper/16x16@2x/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Paper/24x24/apps/ghetto-skype.png
+++ b/Paper/24x24/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Paper/24x24@2x/apps/ghetto-skype.png
+++ b/Paper/24x24@2x/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Paper/32x32/apps/ghetto-skype.png
+++ b/Paper/32x32/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Paper/32x32@2x/apps/ghetto-skype.png
+++ b/Paper/32x32@2x/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Paper/48x48/apps/ghetto-skype.png
+++ b/Paper/48x48/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Paper/48x48@2x/apps/ghetto-skype.png
+++ b/Paper/48x48@2x/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Paper/512x512/apps/ghetto-skype.png
+++ b/Paper/512x512/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Paper/512x512@2x/apps/ghetto-skype.png
+++ b/Paper/512x512@2x/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png

--- a/Paper/scalable/apps/ghetto-skype.png
+++ b/Paper/scalable/apps/ghetto-skype.png
@@ -1,0 +1,1 @@
+skype.png


### PR DESCRIPTION
Adds symlinks to `skype.png` for [Ghetto Skype](https://github.com/stanfieldr/ghetto-skype). It basically uses the same icon as the official client, so it seems logical to link it to skype too.