### PR TITLE
Remove useless Ghetto Skype symlink

### DIFF
--- a/Paper/scalable/apps/ghetto-skype.png
+++ b/Paper/scalable/apps/ghetto-skype.png
@@ -1,1 +1,0 @@
-skype.png


### PR DESCRIPTION
Whoops... It looks like I overdid symlinks to Ghetto Skype, there is one in `scalable/apps` where there is no `skype.png` icon.