### PR TITLE
Added symlinks for Gnome-tweaks 3.27.x

### DIFF
--- a/Paper/16x16/apps/org.gnome.tweaks.png
+++ b/Paper/16x16/apps/org.gnome.tweaks.png
@@ -1,0 +1,1 @@
+utilities-tweak-tool.png

--- a/Paper/16x16@2x/apps/org.gnome.tweaks.png
+++ b/Paper/16x16@2x/apps/org.gnome.tweaks.png
@@ -1,0 +1,1 @@
+utilities-tweak-tool.png

--- a/Paper/24x24/apps/org.gnome.tweaks.png
+++ b/Paper/24x24/apps/org.gnome.tweaks.png
@@ -1,0 +1,1 @@
+utilities-tweak-tool.png

--- a/Paper/24x24@2x/apps/org.gnome.tweaks.png
+++ b/Paper/24x24@2x/apps/org.gnome.tweaks.png
@@ -1,0 +1,1 @@
+utilities-tweak-tool.png

--- a/Paper/32x32/apps/org.gnome.tweaks.png
+++ b/Paper/32x32/apps/org.gnome.tweaks.png
@@ -1,0 +1,1 @@
+utilities-tweak-tool.png

--- a/Paper/32x32@2x/apps/org.gnome.tweaks.png
+++ b/Paper/32x32@2x/apps/org.gnome.tweaks.png
@@ -1,0 +1,1 @@
+utilities-tweak-tool.png

--- a/Paper/48x48/apps/org.gnome.tweaks.png
+++ b/Paper/48x48/apps/org.gnome.tweaks.png
@@ -1,0 +1,1 @@
+utilities-tweak-tool.png

--- a/Paper/48x48@2x/apps/org.gnome.tweaks.png
+++ b/Paper/48x48@2x/apps/org.gnome.tweaks.png
@@ -1,0 +1,1 @@
+utilities-tweak-tool.png

--- a/Paper/512x512/apps/org.gnome.tweaks.png
+++ b/Paper/512x512/apps/org.gnome.tweaks.png
@@ -1,0 +1,1 @@
+utilities-tweak-tool.png

--- a/Paper/512x512@2x/apps/org.gnome.tweaks.png
+++ b/Paper/512x512@2x/apps/org.gnome.tweaks.png
@@ -1,0 +1,1 @@
+utilities-tweak-tool.png

--- a/Paper/scalable/apps/org.gnome.tweaks-symbolic.svg
+++ b/Paper/scalable/apps/org.gnome.tweaks-symbolic.svg
@@ -1,0 +1,1 @@
+utilities-tweak-tool-symbolic.svg


### PR DESCRIPTION
Hi, I'm an author of Adapta-gtk-theme.

Upstream (GNOME) renamed its icon name from 'gnome-tweak-tool' to 'org.gnome.tweaks':
https://gitlab.gnome.org/GNOME/gnome-tweaks/commit/9352deb9381bd8b8ad19f92553fdd935c9f79c2d

I know you are busy but I'm happy if this could be merged. ;)

Regards.