### PR TITLE
Allow configuration outside $(srcdir)

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
 
 set -e
+
+test -n "$srcdir" || srcdir=`dirname "$0"`
+test -n "$srcdir" || srcdir=.
+
+olddir=`pwd`
+cd "$srcdir"
+
 autoreconf --force --install --symlink --warnings=all
 
 if test -z "${NOCONFIGURE}"; then
@@ -8,3 +15,5 @@ if test -z "${NOCONFIGURE}"; then
     ./configure --prefix=/usr "$@"
     make clean
 fi
+
+cd "$olddir"


### PR DESCRIPTION
Currently, autogen.sh can only be executed for the source directory. Fix that by changing directory before doing any further thing. 