### PR TITLE
Added symlinks for Geary 0.12.2

### DIFF
--- a/Paper/16x16/apps/org.gnome.Geary.png
+++ b/Paper/16x16/apps/org.gnome.Geary.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/Paper/16x16@2x/apps/org.gnome.Geary.png
+++ b/Paper/16x16@2x/apps/org.gnome.Geary.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/Paper/24x24/apps/org.gnome.Geary.png
+++ b/Paper/24x24/apps/org.gnome.Geary.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/Paper/24x24@2x/apps/org.gnome.Geary.png
+++ b/Paper/24x24@2x/apps/org.gnome.Geary.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/Paper/32x32/apps/org.gnome.Geary.png
+++ b/Paper/32x32/apps/org.gnome.Geary.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/Paper/32x32@2x/apps/org.gnome.Geary.png
+++ b/Paper/32x32@2x/apps/org.gnome.Geary.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/Paper/48x48/apps/org.gnome.Geary.png
+++ b/Paper/48x48/apps/org.gnome.Geary.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/Paper/48x48@2x/apps/org.gnome.Geary.png
+++ b/Paper/48x48@2x/apps/org.gnome.Geary.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/Paper/512x512/apps/org.gnome.Geary.png
+++ b/Paper/512x512/apps/org.gnome.Geary.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/Paper/512x512@2x/apps/org.gnome.Geary.png
+++ b/Paper/512x512@2x/apps/org.gnome.Geary.png
@@ -1,0 +1,1 @@
+internet-mail.png

--- a/Paper/scalable/apps/org.gnome.Geary-symbolic.svg
+++ b/Paper/scalable/apps/org.gnome.Geary-symbolic.svg
@@ -1,0 +1,1 @@
+internet-mail-symbolic.svg


### PR DESCRIPTION
Hi, I'm an author of Adapta-gtk-theme.

Then upstream renamed its icon name from 'geary' to 'org.gnome.Geary':
https://git.gnome.org/browse/geary/commit/?id=da15ebe3c0c8b5f633dd0c9b91cb2224f7a274c9

It would be nice to be merged for current Geary release. :)