### PR TITLE
Add gnome-system-monitor symlink

### DIFF
--- a/Paper/16x16/apps/gnome-system-monitor.png
+++ b/Paper/16x16/apps/gnome-system-monitor.png
@@ -1,0 +1,1 @@
+utilities-system-monitor.png

--- a/Paper/16x16@2x/apps/gnome-system-monitor.png
+++ b/Paper/16x16@2x/apps/gnome-system-monitor.png
@@ -1,0 +1,1 @@
+utilities-system-monitor.png

--- a/Paper/24x24/apps/gnome-system-monitor.png
+++ b/Paper/24x24/apps/gnome-system-monitor.png
@@ -1,0 +1,1 @@
+utilities-system-monitor.png

--- a/Paper/24x24@2x/apps/gnome-system-monitor.png
+++ b/Paper/24x24@2x/apps/gnome-system-monitor.png
@@ -1,0 +1,1 @@
+utilities-system-monitor.png

--- a/Paper/32x32/apps/gnome-system-monitor.png
+++ b/Paper/32x32/apps/gnome-system-monitor.png
@@ -1,0 +1,1 @@
+utilities-system-monitor.png

--- a/Paper/32x32@2x/apps/gnome-system-monitor.png
+++ b/Paper/32x32@2x/apps/gnome-system-monitor.png
@@ -1,0 +1,1 @@
+utilities-system-monitor.png

--- a/Paper/48x48/apps/gnome-system-monitor.png
+++ b/Paper/48x48/apps/gnome-system-monitor.png
@@ -1,0 +1,1 @@
+utilities-system-monitor.png

--- a/Paper/48x48@2x/apps/gnome-system-monitor.png
+++ b/Paper/48x48@2x/apps/gnome-system-monitor.png
@@ -1,0 +1,1 @@
+utilities-system-monitor.png

--- a/Paper/512x512/apps/gnome-system-monitor.png
+++ b/Paper/512x512/apps/gnome-system-monitor.png
@@ -1,0 +1,1 @@
+utilities-system-monitor.png

--- a/Paper/512x512@2x/apps/gnome-system-monitor.png
+++ b/Paper/512x512@2x/apps/gnome-system-monitor.png
@@ -1,0 +1,1 @@
+utilities-system-monitor.png

--- a/Paper/scalable/apps/gnome-system-monitor-symbolic.svg
+++ b/Paper/scalable/apps/gnome-system-monitor-symbolic.svg
@@ -1,0 +1,1 @@
+utilities-system-monitor-symbolic.svg


### PR DESCRIPTION
Since Gnome 3.30, gnome-system-monitor comes with its own icon instead of using utilities-system-monitor (even if the icons are still exactly the same...)