### PR TITLE
Fix `Paper` mouse cursor theme not being applied in some applications

### DIFF
--- a/Paper/index.theme
+++ b/Paper/index.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=Paper
 Comment=A simple and modern icon theme.
-Inherits=Adwaita,gnome,hicolor
+Inherits=gnome,hicolor
 Example=folder
 
 # KDE/Plasma Stuff


### PR DESCRIPTION
Currently, in some applications `Paper` mouse cursor theme doesn't get applied and fallbacks to `Adwaita`. This can be fixed by removing `Adwaita` from `[Inherits]` section in [Paper/index.theme](https://github.com/snwh/paper-icon-theme/blob/master/Paper/index.theme#L4).

Fixes #694